### PR TITLE
SharedPreferences now caches values in memory for improved performance

### DIFF
--- a/db/src/androidTest/java/io/lantern/db/DBTest.kt
+++ b/db/src/androidTest/java/io/lantern/db/DBTest.kt
@@ -5,6 +5,7 @@ package io.lantern.db
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.After
@@ -683,14 +684,16 @@ class DBTest {
                 "testPreferences",
                 Context.MODE_PRIVATE
             )
-        fallback.edit().putBoolean("fboolean", true).putFloat("ffloat", 1.1.toFloat())
+        fallback.edit().clear().commit()
+        fallback.edit().putBoolean("fboolean", true).putFloat("ffloat", 1.1f)
             .putInt("fint", 2).putLong("flong", 3).putString("fstring", "fallbackstring")
-            .putBoolean("boolean", true).putFloat("float", 1.1.toFloat()).putInt("int", 2)
-            .putLong("long", 3).putString("string", "fallbackstring").commit()
+            .putBoolean("boolean", true).putFloat("float", 1.1f).putInt("int", 2)
+            .putLong("long", 3).putString("string", "fallbackstring")
+            .putInt("intboolean", 1).putLong("longboolean", 1).putString("stringboolean", "true").commit()
         buildDB().use { db ->
             // First set up the preferences without a fallback
             val initPrefs = db.asSharedPreferences("myprefs")
-            initPrefs.edit().putBoolean("boolean", true).putFloat("float", 11.11.toFloat())
+            initPrefs.edit().putBoolean("boolean", true).putFloat("float", 11.11f)
                 .putInt("int", 22)
                 .putLong("long", 33).putString("string", "realstring").commit()
             // Now set it up with the fallback (this ensures that we don't overwrite stuff in the database from the fallback)
@@ -699,15 +702,18 @@ class DBTest {
             assertEquals(
                 mapOf(
                     "fboolean" to true,
-                    "ffloat" to 1.1.toFloat(),
+                    "ffloat" to 1.1f,
                     "fint" to 2,
-                    "flong" to 3.toLong(),
+                    "flong" to 3L,
                     "fstring" to "fallbackstring",
                     "boolean" to true,
-                    "float" to 11.11.toFloat(),
+                    "float" to 11.11f,
                     "int" to 22,
-                    "long" to 33.toLong(),
-                    "string" to "realstring"
+                    "long" to 33L,
+                    "string" to "realstring",
+                    "intboolean" to 1,
+                    "longboolean" to 1L,
+                    "stringboolean" to "true"
                 ),
                 prefs.all
             )
@@ -717,21 +723,24 @@ class DBTest {
                 assertTrue(prefs.getBoolean("boolean", false))
                 assertTrue(prefs.getBoolean("fboolean", false))
                 assertTrue(prefs.getBoolean("uboolean", true))
+                assertTrue(prefs.getBoolean("intboolean", true))
+                assertTrue(prefs.getBoolean("longboolean", true))
+                assertTrue(prefs.getBoolean("stringboolean", true))
 
-                assertEquals(11.11.toFloat(), prefsDB.get<Float>("float"))
-                assertEquals(11.11.toFloat(), prefs.getFloat("float", 111.111.toFloat()))
-                assertEquals(1.1.toFloat(), prefs.getFloat("ffloat", 111.111.toFloat()))
-                assertEquals(111.111.toFloat(), prefs.getFloat("ufloat", 111.111.toFloat()))
+                assertEquals(11.11f, prefsDB.get<Float>("float"))
+                assertEquals(11.11f, prefs.getFloat("float", 111.111f))
+                assertEquals(1.1f, prefs.getFloat("ffloat", 111.111f))
+                assertEquals(111.111f, prefs.getFloat("ufloat", 111.111f))
 
                 assertEquals(22, prefsDB.get<Int>("int"))
                 assertEquals(22, prefs.getInt("int", 222))
                 assertEquals(2, prefs.getInt("fint", 222))
                 assertEquals(222, prefs.getInt("uint", 222))
 
-                assertEquals(33.toLong(), prefsDB.get<Long>("long"))
-                assertEquals(33.toLong(), prefs.getLong("long", 333))
-                assertEquals(3.toLong(), prefs.getLong("flong", 333))
-                assertEquals(333.toLong(), prefs.getLong("ulong", 333))
+                assertEquals(33L, prefsDB.get<Long>("long"))
+                assertEquals(33L, prefs.getLong("long", 333))
+                assertEquals(3L, prefs.getLong("flong", 333))
+                assertEquals(333L, prefs.getLong("ulong", 333))
 
                 assertEquals("realstring", prefsDB.get<String>("string"))
                 assertEquals("realstring", prefs.getString("string", "unknownstring"))

--- a/db/src/main/java/io/lantern/db/SharedPreferencesAdapter.kt
+++ b/db/src/main/java/io/lantern/db/SharedPreferencesAdapter.kt
@@ -14,7 +14,7 @@ import kotlin.collections.HashMap
  * @param initialValues the database will be populated with values from this SharedPreferences for any values that haven't already been set (useful for migrating from a regular SharedPreferences)
  */
 class SharedPreferencesAdapter(
-    val db: DB,
+    internal val db: DB,
     initialValues: SharedPreferences?
 ) : SharedPreferences {
     private val listenerIds = Collections.synchronizedList(ArrayList<ListenerId>())
@@ -31,6 +31,11 @@ class SharedPreferencesAdapter(
             synchronous = true
         )
 
+        /**
+         * Synchronously subscribe to all changes in the schema for these SharedPreferences. That
+         * way, however the underlying properties are updated, the cache will always be up-to-date
+         * with the latest committed values.
+         */
         initialValues?.all?.let {
             db.mutate { tx ->
                 it.forEach { (key, value) ->

--- a/db/src/main/java/io/lantern/db/SharedPreferencesAdapter.kt
+++ b/db/src/main/java/io/lantern/db/SharedPreferencesAdapter.kt
@@ -3,10 +3,12 @@ package io.lantern.db
 import android.content.SharedPreferences
 import java.util.Collections
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.HashMap
 
 /**
- * Allows accessing a DB using the SharedPreferences API.
+ * Allows accessing a DB using the SharedPreferences API. Values are cached in memory for lighter
+ * weight reads.
  *
  * @param db the database in which to store the preferences
  * @param initialValues the database will be populated with values from this SharedPreferences for any values that haven't already been set (useful for migrating from a regular SharedPreferences)
@@ -16,8 +18,19 @@ class SharedPreferencesAdapter(
     initialValues: SharedPreferences?
 ) : SharedPreferences {
     private val listenerIds = Collections.synchronizedList(ArrayList<ListenerId>())
+    private val cache = ConcurrentHashMap<String, Any?>()
 
     init {
+        db.subscribe(
+            object : Subscriber<Any>(UUID.randomUUID().toString(), "") {
+                override fun onChanges(changes: ChangeSet<Any>) {
+                    changes.updates.forEach { cache[it.key] = it.value }
+                    changes.deletions.forEach { cache.remove(it) }
+                }
+            },
+            synchronous = true
+        )
+
         initialValues?.all?.let {
             db.mutate { tx ->
                 it.forEach { (key, value) ->
@@ -28,14 +41,11 @@ class SharedPreferencesAdapter(
     }
 
     override fun getAll(): MutableMap<String, *> {
-        return HashMap(
-            db.list<Any>("%").map { it.path to it.value }
-                .toMap()
-        )
+        return HashMap(cache)
     }
 
     override fun getString(key: String, defValue: String?): String? {
-        return db.get(key) ?: defValue
+        return cache[key]?.let { it as String } ?: defValue
     }
 
     override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String> {
@@ -43,23 +53,39 @@ class SharedPreferencesAdapter(
     }
 
     override fun getInt(key: String, defValue: Int): Int {
-        return db.get(key) ?: defValue
+        var value = cache[key!!] ?: defValue
+        return when (value) {
+            is Number -> value.toInt()
+            is String -> value.toInt()
+            else -> throw ClassCastException("$value cannot be cast to Int")
+        }
     }
 
     override fun getLong(key: String, defValue: Long): Long {
-        return db.get(key) ?: defValue
+        var value = cache[key!!] ?: defValue
+        return when (value) {
+            is Number -> value.toLong()
+            is String -> value.toLong()
+            else -> throw ClassCastException("$value cannot be cast to Long")
+        }
     }
 
     override fun getFloat(key: String, defValue: Float): Float {
-        return db.get(key) ?: defValue
+        return cache[key]?.let { it as Float } ?: defValue
     }
 
     override fun getBoolean(key: String, defValue: Boolean): Boolean {
-        return db.get(key) ?: defValue
+        var value = cache[key!!] ?: defValue
+        return when (value) {
+            is Boolean -> value
+            is Number -> value.toInt() == 1
+            is String -> value.toBoolean()
+            else -> throw ClassCastException("$value cannot be cast to Boolean")
+        }
     }
 
     override fun contains(key: String): Boolean {
-        return db.contains(key)
+        return cache.contains(key)
     }
 
     override fun edit(): SharedPreferences.Editor {


### PR DESCRIPTION
For getlantern/lantern-internal#4924

SharedPreferences may be access quite frequently. Trading off space for time, this change caches SharedPreferences values in memory.

It also incorporates flexible type handling for getLong, getInt and getBoolean in case the fallback preferences used slightly different types to represent these values.

- [x] Do the tests pass? Consistently?