### PR TITLE
Don't use schema for SharedPreferences

### DIFF
--- a/db/src/androidTest/java/io/lantern/db/DBTest.kt
+++ b/db/src/androidTest/java/io/lantern/db/DBTest.kt
@@ -692,12 +692,13 @@ class DBTest {
             .putInt("intboolean", 1).putLong("longboolean", 1).putString("stringboolean", "true").commit()
         buildDB().use { db ->
             // First set up the preferences without a fallback
-            val initPrefs = db.asSharedPreferences("myprefs")
+            val prefsDb = db.withSchema("myprefs")
+            val initPrefs = prefsDb.asSharedPreferences()
             initPrefs.edit().putBoolean("boolean", true).putFloat("float", 11.11f)
                 .putInt("int", 22)
                 .putLong("long", 33).putString("string", "realstring").commit()
             // Now set it up with the fallback (this ensures that we don't overwrite stuff in the database from the fallback)
-            val prefs = db.asSharedPreferences("myprefs", fallback)
+            val prefs = prefsDb.asSharedPreferences(fallback)
 
             assertEquals(
                 mapOf(
@@ -753,7 +754,7 @@ class DBTest {
     @Test
     fun testPreferencesListener() {
         buildDB().use { db ->
-            val prefs = db.asSharedPreferences("prefstest")
+            val prefs = db.withSchema("prefstest").asSharedPreferences()
 
             val updatedKeys = HashSet<String>()
             val listener =

--- a/db/src/main/java/io/lantern/db/DB.kt
+++ b/db/src/main/java/io/lantern/db/DB.kt
@@ -535,14 +535,12 @@ class DB private constructor(
     /**
      * Returns a SharedPreferences backed by this db.
      *
-     * @param schema - preference keys are stored in this named schema
      * @param fallback - an optional fallback SharedPreferences to use for values that aren't found in the db
      */
     fun asSharedPreferences(
-        schema: String,
         fallback: SharedPreferences? = null
     ): SharedPreferencesAdapter {
-        return SharedPreferencesAdapter(this.withSchema(schema), fallback)
+        return SharedPreferencesAdapter(this, fallback)
     }
 
     private fun <T> txExecute(cmd: Callable<T>): T {


### PR DESCRIPTION
For getlantern/android-lantern#206.

This allows reusing a DB instance for backing a SharedPreferences, so that any listeners registered on that DB instances get notified of preference changes.

- [x] Do the tests pass? Consistently?
- [x] Can it be QA’d in staging or something like staging?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [x] Has existing documentation been updated?
